### PR TITLE
API-2934: fixing HAL links to the notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Required Headers:
   - `Accept`
 
 ```
-curl -v -X GET "http://localhost:9649/" \
+curl -v -X DELETE "http://localhost:9649/{notificationId}" \
   -H "X-Client-ID: pHnwo74C0y4SckQUbcoL2DbFAZ0b" \
   -H "Accept: application/vnd.hmrc.1.0+xml"
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Required Headers:
   - `Accept`
 
 ```
-curl -v -X GET "http://localhost:9649/notifications" \
+curl -v -X GET "http://localhost:9649/" \
   -H "X-Client-ID: pHnwo74C0y4SckQUbcoL2DbFAZ0b" \
   -H "Accept: application/vnd.hmrc.1.0+xml"
 ```

--- a/app/uk/gov/hmrc/apinotificationpull/controllers/NotificationsController.scala
+++ b/app/uk/gov/hmrc/apinotificationpull/controllers/NotificationsController.scala
@@ -23,7 +23,7 @@ import play.api.mvc.{Action, AnyContent, Result}
 import uk.gov.hmrc.apinotificationpull.model.XmlErrorResponse
 import uk.gov.hmrc.apinotificationpull.presenters.NotificationPresenter
 import uk.gov.hmrc.apinotificationpull.services.ApiNotificationQueueService
-import uk.gov.hmrc.apinotificationpull.util.XmlBuilder.toXml
+import uk.gov.hmrc.apinotificationpull.util.XmlBuilder
 import uk.gov.hmrc.apinotificationpull.validators.HeaderValidator
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
@@ -33,7 +33,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 @Singleton
 class NotificationsController @Inject()(apiNotificationQueueService: ApiNotificationQueueService,
                                         headerValidator: HeaderValidator,
-                                        notificationPresenter: NotificationPresenter) extends BaseController {
+                                        notificationPresenter: NotificationPresenter,
+                                        xmlBuilder: XmlBuilder) extends BaseController {
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
   private val X_CLIENT_ID_HEADER_NAME = "X-Client-ID"
@@ -65,7 +66,7 @@ class NotificationsController @Inject()(apiNotificationQueueService: ApiNotifica
       }
 
       apiNotificationQueueService.getNotifications()(buildHeaderCarrier()).map {
-        notifications => Ok(toXml(notifications)).as(XML)
+        notifications => Ok(xmlBuilder.toXml(notifications)).as(XML)
       } recover recovery
   }
 }

--- a/app/uk/gov/hmrc/apinotificationpull/util/XmlBuilder.scala
+++ b/app/uk/gov/hmrc/apinotificationpull/util/XmlBuilder.scala
@@ -16,9 +16,12 @@
 
 package uk.gov.hmrc.apinotificationpull.util
 
+import javax.inject.Inject
+
+import uk.gov.hmrc.apinotificationpull.config.AppContext
 import uk.gov.hmrc.apinotificationpull.model.Notifications
 
-object XmlBuilder {
-  private def toXml(notificationLocation: String): scala.xml.Elem = <link rel="notification" href={notificationLocation}/>
+class XmlBuilder @Inject()(appContext: AppContext) {
+  private def toXml(notificationLocation: String): scala.xml.Elem = <link rel="notification" href={s"/${appContext.apiContext}/${notificationLocation.split("/").last}"}/>
   def toXml(notifications: Notifications): scala.xml.Elem = <resource href="/notifications/"><link rel="self" href="/notifications/"/>{notifications.notifications.map( n => toXml(n))}</resource>
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,6 +19,8 @@ include "backend.conf"
 
 appName=api-notification-pull
 
+api.context=notifications
+
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 

--- a/test/it/uk/gov/hmrc/apinotificationpull/acceptance/GetAllNotificationsSpec.scala
+++ b/test/it/uk/gov/hmrc/apinotificationpull/acceptance/GetAllNotificationsSpec.scala
@@ -41,6 +41,7 @@ class GetAllNotificationsSpec extends FeatureSpec with GivenWhenThen with Matche
   private val externalServicesPort = 11111
 
   override def newAppForTest(testData: TestData): Application = new GuiceApplicationBuilder().configure(Map(
+    "api.context" -> "notifications",
     "microservice.services.api-notification-queue.host" -> externalServicesHost,
     "microservice.services.api-notification-queue.port" -> externalServicesPort
   )).build()

--- a/test/unit/uk/gov/hmrc/apinotificationpull/util/XmlBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/apinotificationpull/util/XmlBuilderSpec.scala
@@ -16,16 +16,25 @@
 
 package uk.gov.hmrc.apinotificationpull.util
 
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import uk.gov.hmrc.apinotificationpull.config.AppContext
 import uk.gov.hmrc.apinotificationpull.model.Notifications
-import uk.gov.hmrc.apinotificationpull.util.XmlBuilder.toXml
 import uk.gov.hmrc.play.test.UnitSpec
 
-class XmlBuilderSpec extends UnitSpec {
+class XmlBuilderSpec extends UnitSpec with MockitoSugar {
+
+  trait Setup {
+    val apiContext = "notifications"
+    val appContext = mock[AppContext]
+    when(appContext.apiContext).thenReturn(apiContext)
+    val xmlBuilder = new XmlBuilder(appContext)
+  }
 
   "XmlBuilder.toXml()" should {
 
-    "convert notifications to XML" in {
-      val notifications = Notifications(List("/notifications/123", "/notifications/456"))
+    "convert notifications to XML" in new Setup {
+      val notifications = Notifications(List("/notification/123", "/notification/456"))
 
       val expectedXml = scala.xml.Utility.trim(
         <resource href="/notifications/">
@@ -35,10 +44,10 @@ class XmlBuilderSpec extends UnitSpec {
         </resource>
       )
 
-       toXml(notifications) shouldBe expectedXml
+       xmlBuilder.toXml(notifications) shouldBe expectedXml
     }
 
-    "convert empty notifications to XML" in {
+    "convert empty notifications to XML" in new Setup {
       val notifications = Notifications(Nil)
 
       val expectedXml = scala.xml.Utility.trim(
@@ -47,7 +56,7 @@ class XmlBuilderSpec extends UnitSpec {
         </resource>
       )
 
-      toXml(notifications) shouldBe expectedXml
+      xmlBuilder.toXml(notifications) shouldBe expectedXml
     }
 
   }


### PR DESCRIPTION
The queue service returns `/notification/{notificationId}` as a notification location. We need to expose this to the client as `/notifications/{notificationId}` so the path is correct for this service, `notifications` being the context of this service